### PR TITLE
fix jumpratio for deleting rule from ruleset

### DIFF
--- a/train.c
+++ b/train.c
@@ -728,7 +728,7 @@ ruleset_proposal(ruleset_t * rs, int nrules,
 		//cannot delete the default rule
 			index2 = 0;
 		//index2 doesn 't matter in this case
-			* jumpRatio = jumpRatios[2] * (nrules - rs->n_rules);
+			* jumpRatio = jumpRatios[2] / (nrules - rs->n_rules);
 		*stepchar = 'D';
 	} else {
 		//should raise exception here.


### PR DESCRIPTION
The jump ratio for the 'cut' on a ruleset should be `jumpRatios[2] / (nrules - rs->n_rules);` instead of `jumpRatios[2] * (nrules - rs->n_rules);`. See original python implementation by Letham et. al (`BRL_code.py`).
